### PR TITLE
chore: point at stats.ipfs.network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,3 @@
-# Nebula Crawler Measurement Reports
+# Nebula Crawler Measurement Reports moved
 
-## 2023
-
-### IPFS
-
-- [Calendar Week 0](2023/calendar-week-0/ipfs/README.md)
-- [Calendar Week 1](2023/calendar-week-1/ipfs/README.md)
-- [Calendar Week 2](2023/calendar-week-2/ipfs/README.md)
-- [Calendar Week 3](2023/calendar-week-3/ipfs/README.md)
-- [Calendar Week 4](2023/calendar-week-4/ipfs/README.md)
-
-## 2021
-
-### IPFS
-
-- [Calendar Week 42](2021/calendar-week-42/ipfs/README.md)
-- [Calendar Week 43](2021/calendar-week-43/ipfs/README.md)
-- [Calendar Week 44](2021/calendar-week-44/ipfs/README.md)
-- [Calendar Week 49](2021/calendar-week-49/ipfs/README.md)
-
-### Filecoin
-
-- [Calendar Week 43](2021/calendar-week-43/filecoin/README.md)
+See https://stats.ipfs.network/ or https://github.com/protocol/network-measurements/tree/master/reports


### PR DESCRIPTION
Googling "Nebula Crawler Reports" always finds this repo, which is no longer kept up-to-date, 
things seem to be moved to https://github.com/protocol/network-measurements/tree/master/reports

@dennis-tra @yiannisbot Would it be ok to point people at the new home?